### PR TITLE
db_find() debe devolver tupla vacía

### DIFF
--- a/cinebot/services/base.py
+++ b/cinebot/services/base.py
@@ -213,7 +213,7 @@ class ServiceBase(object):
 
     def db_find(self, collection, query=None):
         if not self.db:
-            return
+            return ()
         return self.db[collection].find(query or {})
 
     def db_save_many(self, collection, datas):


### PR DESCRIPTION
Cuando no hay base de datos db_find() debe devolver una tupla vacía
porque si no db_get_or_create() no puede crear una lista a partir de un
None.